### PR TITLE
没有开启debug 所有不是think\exception\RuntimeException及继承的异常的错误信息都屏蔽

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /.idea
+/composer.lock

--- a/src/think/App.php
+++ b/src/think/App.php
@@ -496,7 +496,7 @@ class App
         } catch (HttpResponseException $exception) {
             $data = $exception->getResponse();
         } catch (\Throwable $e) {
-            $data = Response::create(["code" => $e->getCode(), "msg" => $e->getMessage()], "json");;
+            $data = static::exceptionResponse($e, $request);
         }
 
 

--- a/src/think/exception/ExceptionHandler.php
+++ b/src/think/exception/ExceptionHandler.php
@@ -11,6 +11,7 @@
  * @link      http://www.workerman.net/
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
  */
+
 namespace think\exception;
 
 use Throwable;
@@ -83,7 +84,10 @@ class ExceptionHandler implements ExceptionHandlerInterface
             $error = $this->_debug ? nl2br((string)$exception) : 'Server internal error';
             $json = ['code' => $code ? $code : 500, 'msg' => $error];
         }
-
+        if (!$this->_debug && $exception instanceof DbException) {
+            $json['msg'] = 'Server internal error';
+        }
+        $this->_debug && $json['traces'] = (string)$exception;
         return new Response(json_encode($json, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES), 200, ['Content-Type' => 'application/json']);
 
     }

--- a/src/think/exception/ExceptionHandler.php
+++ b/src/think/exception/ExceptionHandler.php
@@ -84,7 +84,8 @@ class ExceptionHandler implements ExceptionHandlerInterface
             $error = $this->_debug ? nl2br((string)$exception) : 'Server internal error';
             $json = ['code' => $code ? $code : 500, 'msg' => $error];
         }
-        if (!$this->_debug && $exception instanceof DbException) {
+        // 没有开启debug 所有不是think\exception\LogicException的都屏蔽错误
+        if (!$this->_debug && !$exception instanceof LogicException) {
             $json['msg'] = 'Server internal error';
         }
         $this->_debug && $json['traces'] = (string)$exception;

--- a/src/think/exception/ExceptionHandler.php
+++ b/src/think/exception/ExceptionHandler.php
@@ -85,7 +85,7 @@ class ExceptionHandler implements ExceptionHandlerInterface
             $json = ['code' => $code ? $code : 500, 'msg' => $error];
         }
         // 没有开启debug 所有不是think\exception\LogicException的都屏蔽错误
-        if (!$this->_debug && !$exception instanceof LogicException) {
+        if (!$this->_debug && !$exception instanceof RuntimeException) {
             $json['msg'] = 'Server internal error';
         }
         $this->_debug && $json['traces'] = (string)$exception;

--- a/src/think/exception/HttpResponseException.php
+++ b/src/think/exception/HttpResponseException.php
@@ -13,7 +13,7 @@ namespace think\exception;
 
 use think\response;
 
-class HttpResponseException extends \RuntimeException
+class HttpResponseException extends RuntimeException
 {
     /**
      * @var Response

--- a/src/think/exception/LogicException.php
+++ b/src/think/exception/LogicException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace think\exception;
+
+/**
+ * 业务异常
+ * 可抛出给业务的可读错误信息
+ */
+class LogicException extends \LogicException
+{
+
+}

--- a/src/think/exception/RuntimeException.php
+++ b/src/think/exception/RuntimeException.php
@@ -3,10 +3,10 @@
 namespace think\exception;
 
 /**
- * 业务异常
+ * 运行时业务异常
  * 可抛出给业务的可读错误信息
  */
-class LogicException extends \LogicException
+class RuntimeException extends \RuntimeException
 {
 
 }


### PR DESCRIPTION
 
1. 新增了 think\exception\RuntimeException 
2. 修改HttpResponseException继承于RuntimeException  
3. APP_DEBUG = false 只输出继承于RuntimeException的错误信息,其他都屏蔽成 "Server internal error"